### PR TITLE
lightbox images are draggable

### DIFF
--- a/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
+++ b/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
@@ -110,7 +110,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                 >
                   <div
                     class="ril-image-current ril__image ril-not-loaded"
-                    style="transform: scale3d(1,1,1);"
+                    style="transform: translate(0px,0px) scale3d(undefined,undefined,1);"
                   >
                     <div
                       class="ril__loadingContainer"
@@ -396,7 +396,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                   key="/fake/image/src.jpgi0"
                   style={
                     Object {
-                      "transform": "scale3d(1,1,1)",
+                      "transform": "translate(0px,0px) scale3d(undefined,undefined,1)",
                     }
                   }
                 >

--- a/src/lightbox-react.js
+++ b/src/lightbox-react.js
@@ -61,15 +61,14 @@ class ReactImageLightbox extends Component {
   }
 
   // Request to transition to the previous image
-  static getTransform({ zoom = 1, width, targetWidth }) {
-    let scaleFactor = zoom;
+  // Determine x, y translation
+  static getTransform({ x = 0, y = 0, zoom = 1, width, targetWidth}) {
+    let scaleFactor;
     if (width && targetWidth) {
       scaleFactor = zoom * (targetWidth / width);
     }
 
-    return {
-      transform: `scale3d(${scaleFactor},${scaleFactor},1)`,
-    };
+    return { transform: `translate(${x}px,${y}px) scale3d(${scaleFactor},${scaleFactor},1)` };
   }
 
   constructor(props) {


### PR DESCRIPTION
#### What's this PR do?
adds "translate(x,y)" to `getTransform` function

#### Who did you pair with on this change?

#### How should this be manually tested?
see if you can drag images once you've zoomed in

#### Did you run linting, tests and check for new console warnings?
yes

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### What gif best describes how this PR makes you feel?
![](https://media.giphy.com/media/HAK4Z2ta1dQas/giphy.gif)
